### PR TITLE
Add --no-signin option for better system auth integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Move the built binary (inside the `bin` directory) to somewhere in your PATH.
 git config --global credential.helper '!git-credential-1password'
 ```
 
+If you've enabled 1Password CLI system authentication integration, you
+may need to add the `--no-signin` flag for proper operation:
+
+```shell script
+git config --global credential.helper '!git-credential-1password --no-signin'
+```
+
 ## Support
 
 This project is maintained by [@develerik](https://github.com/develerik). Please understand that we won't be able to

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -6,10 +6,11 @@ import (
 )
 
 var (
-	account string
-	cache   uint
-	archive bool
-	vault   string
+	account  string
+	cache    uint
+	archive  bool
+	vault    string
+	noSignin bool
 )
 
 // rootCmd represents the base command when called without any subcommands.
@@ -67,6 +68,9 @@ func Execute() error {
 
 	rootCmd.PersistentFlags().StringVarP(&vault, "vault", "v", "",
 		"the vault to use for your git credentials")
+
+	rootCmd.PersistentFlags().BoolVar(&noSignin, "no-signin", false,
+		"Skip the 'op signin' step.  Use this option if you've enabled 1Password CLI system authentication integration")
 
 	return rootCmd.Execute()
 }

--- a/cmd/erase.go
+++ b/cmd/erase.go
@@ -35,8 +35,9 @@ func deleteCredentials(r io.Reader) error {
 	}
 
 	c := onepassword.Client{
-		Account: account,
-		Vault:   vault,
+		Account:  account,
+		Vault:    vault,
+		NoSignin: noSignin,
 	}
 
 	if err := c.Login(cache); err != nil {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -36,8 +36,9 @@ func getCredentials(r io.Reader, w io.Writer) error {
 	}
 
 	c := onepassword.Client{
-		Account: account,
-		Vault:   vault,
+		Account:  account,
+		Vault:    vault,
+		NoSignin: noSignin,
 	}
 
 	if err := c.Login(cache); err != nil {

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -35,8 +35,9 @@ func storeCredentials(r io.Reader) error {
 	}
 
 	c := onepassword.Client{
-		Account: account,
-		Vault:   vault,
+		Account:  account,
+		Vault:    vault,
+		NoSignin: noSignin,
 	}
 
 	if err := c.Login(cache); err != nil {

--- a/onepassword/client.go
+++ b/onepassword/client.go
@@ -2,7 +2,8 @@ package onepassword
 
 // Client defines a 1password client.
 type Client struct {
-	token   string
-	Account string
-	Vault   string
+	token    string
+	Account  string
+	Vault    string
+	NoSignin bool
 }

--- a/onepassword/login.go
+++ b/onepassword/login.go
@@ -38,6 +38,10 @@ func getTTYPath() (string, error) {
 
 // Login to 1password.
 func (c *Client) Login(timeout uint) error { //nolint:funlen,gocyclo // TODO: refactor
+	if c.NoSignin {
+		return nil
+	}
+
 	var err error
 	c.token, err = git.GetFromCache(c.Account)
 


### PR DESCRIPTION
`Client.login()` expects the `op signin` command to return a session token that can be used for subsequent commands.  However, when 1Password CLI integration with system authentication has been enabled, this token is not returned and the helper errors out with `no session token found`.  In addition, the prompt for the master password is redundant in this scenario.

To work around this problem, this commit adds a --no-signin flag that can be passed to git-credential-1password to make it skip the login step.  The user will be prompted for authentication by the operating system when needed.

Possibly closes: #20
